### PR TITLE
Fix Renovate setup

### DIFF
--- a/games/data.csv
+++ b/games/data.csv
@@ -916,3 +916,27 @@ Sokobond,Already owned,,Draknek & Friends: 12 Years of Great Puzzle Games!,58327
 Cosmic Express,Already owned,,Draknek & Friends: 12 Years of Great Puzzle Games!,583270
 Bonfire Peaks,,,Draknek & Friends: 12 Years of Great Puzzle Games!,1147890
 A Monster's Expedition,Already owned,,Draknek & Friends: 12 Years of Great Puzzle Games!,1052990
+"Sonic Frontiers",,,"Humble Choice: January 2026","1237320"
+"Tomb Raider IV-VI Remastered",,,"Humble Choice: January 2026","2525380"
+"Hunt: Showdown 1896",,,"Humble Choice: January 2026","594650"
+"Nice Day for Fishing","Already owned",,"Humble Choice: January 2026","2393160"
+"Metal Slug Tactics",,,"Humble Choice: January 2026","1590760"
+"Settlement Survival",,,"Humble Choice: January 2026","1509510"
+"Wizard of Legend 2",,,"Humble Choice: January 2026","2193540"
+"Resident Evil Village",,,"Humble Choice: February 2026","1196590"
+"Date Everything",,,"Humble Choice: February 2026","2201320"
+"Core Keeper",,,"Humble Choice: February 2026","1621690"
+"StarVaders",,,"Humble Choice: February 2026","2097570"
+"Squirrel with a Gun",,,"Humble Choice: February 2026","2067050"
+"SteamWorld Build",,,"Humble Choice: February 2026","2134770"
+"Bus Simulator 21 Next Stop",,,"Humble Choice: February 2026","976590"
+"Big Helmet Heroes",,,"Humble Choice: February 2026","2397250"
+"Tempest Rising",,,"Humble Choice: March 2026","1486920"
+"Chants of Sennaar",,"Yes! Easily one of the smartest, most fun games I have ever played!","Humble Choice: March 2026","1931770"
+"Sworn",,,"Humble Choice: March 2026","1763250"
+"Etrian Odyssey III HD",,,"Humble Choice: March 2026","1810820"
+"Bread & Fred",,,"Humble Choice: March 2026","1607680"
+"Zero Hour",,,"Humble Choice: March 2026","1359090"
+"Smalland: Survive the Wild",,,"Humble Choice: March 2026","768200"
+"Hard West 2",,,"Humble Choice: March 2026","1282410"
+,,,,

--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,10 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "schedule": ["before 06:00 on monday"],
+  "schedule": ["before 08:00 on monday"],
   "timezone": "Europe/Berlin",
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
+  "prConcurrentLimit": 20,
   "branchConcurrentLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
Widen the weekly Renovate schedule window and cap concurrent open PRs at 20 so updates flow without flooding.